### PR TITLE
Set add-on id to use

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,5 +28,11 @@
     "sessions",
     "storage",
     "tabs"
-  ]
+  ],
+
+  "applications": {
+    "gecko": {
+      "id": "dormancy@autonome.github.io"
+    }
+  }
 }


### PR DESCRIPTION
When using storage you need to set an add-on ID.

This prevents the error: "Error: Sessions API storage methods will not work with a temporary addon ID. Please add an explicit addon ID to your manifest."